### PR TITLE
fix: use chrome env settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ Install all dependencies:
 npm install
 ```
 
+The included `vercel.json` file sets environment variables so Puppeteer uses the
+Chrome binary provided by `chrome-aws-lambda`:
+
+```json
+{
+  "env": {
+    "PUPPETEER_PRODUCT": "chrome",
+    "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD": "true"
+  }
+}
+```
+
 Login to your Vercel account and setup a project:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "lint": "eslint --ignore-path .gitignore . --ext .js",
     "develop": "vercel dev",
-    "deploy": "vercel deploy --prod"
+    "deploy": "vercel deploy --prod",
+    "postinstall": "echo 'Using chrome-aws-lambda, skipping Puppeteer download'"
   },
   "repository": {
     "type": "git",
@@ -19,7 +20,6 @@
   "homepage": "https://github.com/BetaHuhn/vercel-pdf-converter#readme",
   "dependencies": {
     "chrome-aws-lambda": "^5.5.0",
-    "puppeteer": "^5.5.0",
     "puppeteer-core": "^5.5.0",
     "puppeteer-extra": "^3.1.15",
     "puppeteer-extra-plugin-adblocker": "^2.11.9",
@@ -29,5 +29,8 @@
     "@betahuhn/eslint-config-node": "^0.1.1",
     "eslint": "^7.13.0",
     "vercel": "^19.1.1"
+  },
+  "engines": {
+    "node": ">=12.x"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,14 @@
 {
-	"rewrites": [
-		{ "source": "/(.*)", "destination": "/api" }
-	]
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/api" }
+  ],
+  "functions": {
+    "api/index.js": {
+      "maxDuration": 30
+    }
+  },
+  "env": {
+    "PUPPETEER_PRODUCT": "chrome",
+    "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD": "true"
+  }
 }


### PR DESCRIPTION
## Summary
- switch README to mention chrome-based install
- prevent downloading puppeteer binary in postinstall
- remove regular puppeteer dependency and require Node 12+
- configure Vercel env vars and function timeout

## Testing
- `npm run lint` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cf74e5648832982b9b29bfcb7f767