### PR TITLE
fix: firefox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,20 @@ git clone https://github.com/BetaHuhn/vercel-pdf-converter
 Install all dependencies:
 
 ```sh
-npm install
+npm run install:firefox
+```
+
+The included `vercel.json` file sets environment variables so Puppeteer uses Firefox:
+
+```json
+{
+  "build": {
+    "env": {
+      "PUPPETEER_PRODUCT": "firefox",
+      "PUPPETEER_EXECUTABLE_PATH": "/usr/bin/firefox"
+    }
+  }
+}
 ```
 
 Login to your Vercel account and setup a project:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "lint": "eslint --ignore-path .gitignore . --ext .js",
     "develop": "vercel dev",
-    "deploy": "vercel deploy --prod"
+    "deploy": "vercel deploy --prod",
+    "install:firefox": "PUPPETEER_PRODUCT=firefox npm install",
+    "postinstall": "echo 'Installing Firefox for Puppeteer'"
   },
   "repository": {
     "type": "git",
@@ -18,9 +20,7 @@
   },
   "homepage": "https://github.com/BetaHuhn/vercel-pdf-converter#readme",
   "dependencies": {
-    "chrome-aws-lambda": "^5.5.0",
     "puppeteer": "^5.5.0",
-    "puppeteer-core": "^5.5.0",
     "puppeteer-extra": "^3.1.15",
     "puppeteer-extra-plugin-adblocker": "^2.11.9",
     "puppeteer-extra-plugin-stealth": "^2.6.5"
@@ -29,5 +29,8 @@
     "@betahuhn/eslint-config-node": "^0.1.1",
     "eslint": "^7.13.0",
     "vercel": "^19.1.1"
+  },
+  "engines": {
+    "node": ">=12.x"
   }
 }

--- a/service/convert.js
+++ b/service/convert.js
@@ -1,4 +1,4 @@
-import chrome from 'chrome-aws-lambda'
+import puppeteer from 'puppeteer'
 import { addExtra } from 'puppeteer-extra'
 import AdblockerPlugin from 'puppeteer-extra-plugin-adblocker'
 
@@ -21,7 +21,7 @@ import WebglVendorPlugin from 'puppeteer-extra-plugin-stealth/evasions/webgl.ven
 import WindowOuterDimensionsPlugin from 'puppeteer-extra-plugin-stealth/evasions/window.outerdimensions'
 
 // Configure puppeteer-extra plugins
-const puppeteer = addExtra(chrome.puppeteer)
+const puppeteerExtra = addExtra(puppeteer)
 const plugins = [
 	AdblockerPlugin({ blockTrackers: true }),
 	StealthPlugin(),
@@ -42,42 +42,20 @@ const plugins = [
 	WindowOuterDimensionsPlugin()
 ]
 
-// Or just use puppeteer directly
-// import puppeteer from 'puppeteer-core'
-
-const isDev = process.env.NODE_ENV === 'development'
-
-// Path to chrome executable on different platforms
-const chromeExecutables = {
-	linux: '/usr/bin/chromium-browser',
-	win32: 'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
-	darwin: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-}
-
-export const getOptions = async (isDev) => {
-
-	// During development use local chrome executable
-	if (isDev) {
-		return {
-			args: [],
-			executablePath: chromeExecutables[process.platform] || chromeExecutables.linux,
-			headless: true
-		}
+// Build launch options based on environment variables
+export const getOptions = () => {
+	const options = { headless: true }
+	if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+		options.executablePath = process.env.PUPPETEER_EXECUTABLE_PATH
 	}
-
-	// Else, use the path of chrome-aws-lambda and its args
-	return {
-		args: chrome.args,
-		executablePath: await chrome.executablePath,
-		headless: chrome.headless
-	}
+	return options
 }
 
 export const getPdf = async (url) => {
 
-	// Start headless chrome instance
-	const options = await getOptions(isDev)
-	const browser = await puppeteer.launch(options)
+	// Start headless browser instance
+	const options = getOptions()
+	const browser = await puppeteerExtra.launch(options)
 
 	// Load all plugins manually
 	for (const plugin of plugins) {
@@ -107,7 +85,7 @@ export const getPdf = async (url) => {
 		})
 	})
 
-	// Tell Chrome to generate the PDF
+	// Tell the browser to generate the PDF
 	await page.emulateMediaType('screen')
 	const buffer = await page.pdf({
 		format: 'A4',
@@ -117,7 +95,7 @@ export const getPdf = async (url) => {
 		printBackground: true
 	})
 
-	// Close chrome instance
+	// Close browser instance
 	await browser.close()
 
 	return buffer

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,16 @@
 {
-	"rewrites": [
-		{ "source": "/(.*)", "destination": "/api" }
-	]
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/api" }
+  ],
+  "build": {
+    "env": {
+      "PUPPETEER_PRODUCT": "firefox",
+      "PUPPETEER_EXECUTABLE_PATH": "/usr/bin/firefox"
+    }
+  },
+  "functions": {
+    "api/index.js": {
+      "maxDuration": 30
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- configure Vercel for Firefox runtime
- update install script and dependencies for Puppeteer Firefox
- adapt README for the new installation method
- refactor converter service to use generic Puppeteer

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688cf74e5648832982b9b29bfcb7f767