### PR TITLE
Move interface to /vpdf and add noindex placeholder

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,43 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Vercel PDF Converter</title>
-    <meta name="title" content="Vercel PDF Converter">
-    <meta name="description" content="Vercel function which generates PDFs from Webpages.">
-    <link rel="stylesheet" href="/main.css">
+  <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
+  <title></title>
 </head>
 <body>
-    <div id="error" style="display: none;">
-        <p id="error-msg"></p>
-    </div>
-    <div class="wrapper">
-        <div class="banner">
-            <div class="svg">
-                <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid meet" viewBox="0 0 512 512" style="-ms-transform: rotate(360deg); -webkit-transform: rotate(360deg); transform: rotate(360deg);"><path fill-rule="evenodd" d="M256 48l240 416H16z" fill="white"/><rect x="0" y="0" fill="rgba(0, 0, 0, 0)" /></svg>
-            </div>
-            <div class="content">
-                <h1>Vercel PDF Converter</h1>
-                <p>Place <span id="host" title="Click to copy" onclick="copy()"></span> in front of any URL to generate a PDF version of it.</p>
-            </div>
-        </div>
-        <div class="actions">
-            <div id="input-container" class="input-container noselect">
-                <p class="input-label noselect">Or enter a URL here</p>
-                <div class="center">
-                    <input id="url" type="url" class="url-input" autocomplete="off" placeholder="https://..." onkeyup="onInput(this)">
-                </div>
-            </div>
-            <p id="go" href="/" onclick="generate()">Generate!</p>
-        </div>
-    </div>
-    <div class="about">
-        <p>Visit <a href="https://github.com/BetaHuhn/vercel-pdf-converter">GitHub</a></p>
-        <p>or</p>
-        <a href="https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2FBetaHuhn%2Fvercel-pdf-converter"><img src="https://vercel.com/button" alt="Deploy with Vercel"/></a>
-    </div>
-    <script src="/main.js"></script>
 </body>
 </html>

--- a/public/vpdf/index.html
+++ b/public/vpdf/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Vercel PDF Converter</title>
+    <meta name="title" content="Vercel PDF Converter">
+    <meta name="description" content="Vercel function which generates PDFs from Webpages.">
+    <link rel="stylesheet" href="/main.css">
+</head>
+<body>
+    <div id="error" style="display: none;">
+        <p id="error-msg"></p>
+    </div>
+    <div class="wrapper">
+        <div class="banner">
+            <div class="svg">
+                <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid meet" viewBox="0 0 512 512" style="-ms-transform: rotate(360deg); -webkit-transform: rotate(360deg); transform: rotate(360deg);"><path fill-rule="evenodd" d="M256 48l240 416H16z" fill="white"/><rect x="0" y="0" fill="rgba(0, 0, 0, 0)" /></svg>
+            </div>
+            <div class="content">
+                <h1>Vercel PDF Converter</h1>
+                <p>Place <span id="host" title="Click to copy" onclick="copy()"></span> in front of any URL to generate a PDF version of it.</p>
+            </div>
+        </div>
+        <div class="actions">
+            <div id="input-container" class="input-container noselect">
+                <p class="input-label noselect">Or enter a URL here</p>
+                <div class="center">
+                    <input id="url" type="url" class="url-input" autocomplete="off" placeholder="https://..." onkeyup="onInput(this)">
+                </div>
+            </div>
+            <p id="go" href="/" onclick="generate()">Generate!</p>
+        </div>
+    </div>
+    <div class="about">
+        <p>Visit <a href="https://github.com/BetaHuhn/vercel-pdf-converter">GitHub</a></p>
+        <p>or</p>
+        <a href="https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2FBetaHuhn%2Fvercel-pdf-converter"><img src="https://vercel.com/button" alt="Deploy with Vercel"/></a>
+    </div>
+    <script src="/main.js"></script>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,7 @@
 {
   "rewrites": [
+    { "source": "/vpdf", "destination": "/vpdf/index.html" },
+    { "source": "/vpdf/(.*)", "destination": "/vpdf/$1" },
     { "source": "/(.*)", "destination": "/api" }
   ],
   "build": {


### PR DESCRIPTION
## Summary
- Move existing index.html content to `/vpdf` and add blank root page with `noindex`
- Update `vercel.json` rewrites to serve `/vpdf` while keeping API routing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688da98be1008329b69d05fc3f1a651c